### PR TITLE
Remove taxgate.com subdomain

### DIFF
--- a/index.md
+++ b/index.md
@@ -88,7 +88,7 @@ contra
   über mehrere Generationen wird durch eine GmbH nicht umbedingt einfacher.
   Geldanlage bleibt eine sehr individuelle Entscheidung, angepasst an die eigene Lebenssituation und die
   eigenen Bedürfnisse.
-- <https://www.taxgate.com/trading-gmbh-spardosen-gmbh-etc-macht-das-sinn/>
+- <https://taxgate.com/trading-gmbh-spardosen-gmbh-etc-macht-das-sinn>
 
 
 <!--- newpage -->


### PR DESCRIPTION
The taxgate.com server does not require a subdomain or this is not configured. The correct link is https://taxgate.com/trading-gmbh-spardosen-gmbh-etc-macht-das-sinn/